### PR TITLE
recalcInternals fix for framebuffer size

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -445,8 +445,6 @@ bool Renderer::doesItFitInMemory(size_t size)
 
 void Renderer::recalcInternals()
 {
-    bool is16by9 = false;
-
     viewWidth = window_size_x;
     viewHeight = window_size_y;
 
@@ -469,26 +467,26 @@ void Renderer::recalcInternals()
         }
     }
 
-    if ((viewWidth % game_width) > 0 || (viewHeight % game_height) > 0)
+	// If internal_resolution_scale from settings is less than one, calculate the closest fit for the output resolution, otherwise use the value directly
+    if (internal_resolution_scale < 1)
     {
         long scaleW = ::round(viewWidth / (float)game_width);
         long scaleH = ::round(viewHeight / (float)game_height);
 
         if (scaleH > scaleW) scaleW = scaleH;
-        if (scaleW > internal_resolution_scale) internal_resolution_scale = scaleW + 1;
-
-        is16by9 = true;
+        if (scaleW > internal_resolution_scale) internal_resolution_scale = scaleW;
+		if (internal_resolution_scale < 1) internal_resolution_scale = 1;
     }
 
-    // In order to prevent weird glitches while rendering we need to use the closest resolution to native's game one
-    framebufferWidth = is16by9 ? game_width * internal_resolution_scale : viewWidth * internal_resolution_scale;
-    framebufferHeight = is16by9 ? game_height * internal_resolution_scale : viewHeight * internal_resolution_scale;
+    // Use the set or calculated scaling factor to determine the width and height of the framebuffer according to the original resolution
+    framebufferWidth = game_width * internal_resolution_scale;
+    framebufferHeight = game_height * internal_resolution_scale;
 
     framebufferVertexWidth = (viewWidth * game_width) / window_size_x;
     framebufferVertexOffsetX = (game_width - framebufferVertexWidth) / 2;
 
     // Let the user know about chosen resolutions
-    ffnx_info("Original resolution %ix%i, New resolution %ix%i, Internal resolution %ix%i\n", game_width, game_height, window_size_x, window_size_y, framebufferWidth, framebufferHeight);
+    ffnx_info("Original resolution %ix%i, Scaling factor %i, Internal resolution %ix%i, Output resolution %ix%i\n", game_width, game_height, internal_resolution_scale, framebufferWidth, framebufferHeight, window_size_x, window_size_y);
 }
 
 void Renderer::prepareFramebuffer()


### PR DESCRIPTION
This is intended to fix an issue of inconsistent behavior at certain resolutions.  In addition, it should make upscaling the internal resolution from the original game resolution consistent across the board.  This will require that the default value of internal_resolution_scale in the FFNx.toml file be changed to 0 or less, which will mean by default the new code will attempt to calculate an optimal fit.